### PR TITLE
Uncomment asserts for invalid empty routes

### DIFF
--- a/Tests/MQTTnet.AspNetCore.Routing.Tests/RouteTemplateParserTests.cs
+++ b/Tests/MQTTnet.AspNetCore.Routing.Tests/RouteTemplateParserTests.cs
@@ -139,8 +139,8 @@ namespace MQTTnet.AspNetCore.Routing.Tests
             // Act
 
             // Assert
-           // Assert.ThrowsException<InvalidOperationException>(() => TemplateParser.ParseTemplate(""));
-          //  Assert.ThrowsException<InvalidOperationException>(() => TemplateParser.ParseTemplate("/"));
+            Assert.ThrowsException<InvalidOperationException>(() => TemplateParser.ParseTemplate(""));
+            Assert.ThrowsException<InvalidOperationException>(() => TemplateParser.ParseTemplate("/"));
         }
 
         [TestMethod]


### PR DESCRIPTION
## Summary
- enable asserts in `Parse_EmptyRoutesShouldFail`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687637373f2c8332984d7a90ac174eb8