### PR TITLE
Fix parameter name typo

### DIFF
--- a/Source/Routing/MqttRouter.cs
+++ b/Source/Routing/MqttRouter.cs
@@ -172,7 +172,7 @@ namespace MQTTnet.Extensions.ManagedClient.Routing.Routing
         }
 
         private static object? MatchParameterOrThrow(ParameterInfo param,
-            IReadOnlyDictionary<string, object> availableParmeters, MqttControllerContext controllerContext,
+            IReadOnlyDictionary<string, object> availableParameters, MqttControllerContext controllerContext,
             IServiceProvider serviceProvider)
         {
             if (param.IsDefined(typeof(FromPayloadAttribute), false))
@@ -185,7 +185,7 @@ namespace MQTTnet.Extensions.ManagedClient.Routing.Routing
                 );
             }
 
-            if (!availableParmeters.TryGetValue(param.Name, out object? value))
+            if (!availableParameters.TryGetValue(param.Name, out object? value))
             {
                 if (param.IsOptional)
                 {


### PR DESCRIPTION
## Summary
- fix typo in `MatchParameterOrThrow` parameter naming
- update usages accordingly

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876373796a88332adc63045f0c1d601