### PR TITLE
Fix Key equality implementation

### DIFF
--- a/Source/Routing/MqttRouteTableFactory.cs
+++ b/Source/Routing/MqttRouteTableFactory.cs
@@ -280,7 +280,7 @@ namespace MQTTnet.Extensions.ManagedClient.Routing.Routing
 
             public override bool Equals(object obj)
             {
-                return obj is Key other && base.Equals(other);
+                return obj is Key other && Equals(other);
             }
 
             public bool Equals(Key other)

--- a/Tests/MQTTnet.AspNetCore.Routing.Tests/MqttRouteTableFactoryKeyTests.cs
+++ b/Tests/MQTTnet.AspNetCore.Routing.Tests/MqttRouteTableFactoryKeyTests.cs
@@ -1,0 +1,49 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Reflection;
+using System;
+using MQTTnet.Extensions.ManagedClient.Routing.Routing;
+
+namespace MQTTnet.AspNetCore.Routing.Tests
+{
+    [TestClass]
+    public class MqttRouteTableFactoryKeyTests
+    {
+        private static Type GetKeyType()
+        {
+            return typeof(MqttRouteTableFactory).GetNestedType("Key", BindingFlags.NonPublic);
+        }
+
+        private static object CreateKey(Assembly[] assemblies)
+        {
+            var keyType = GetKeyType();
+            var ctor = keyType.GetConstructor(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public, null, new[] { typeof(Assembly[]) }, null);
+            return ctor.Invoke(new object[] { assemblies });
+        }
+
+        private static bool InvokeEquals(object key1, object key2)
+        {
+            var keyType = GetKeyType();
+            var method = keyType.GetMethod("Equals", new[] { keyType });
+            return (bool)method.Invoke(key1, new[] { key2 });
+        }
+
+        [TestMethod]
+        public void Equals_ReturnsTrue_ForSameAssemblies()
+        {
+            var asm = new[] { typeof(MqttRouteTableFactoryKeyTests).Assembly };
+            var key1 = CreateKey(asm);
+            var key2 = CreateKey(new[] { typeof(MqttRouteTableFactoryKeyTests).Assembly });
+
+            Assert.IsTrue(InvokeEquals(key1, key2));
+        }
+
+        [TestMethod]
+        public void Equals_ReturnsFalse_ForDifferentAssemblies()
+        {
+            var key1 = CreateKey(new[] { typeof(string).Assembly });
+            var key2 = CreateKey(new[] { typeof(int).Assembly });
+
+            Assert.IsFalse(InvokeEquals(key1, key2));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- ensure Key.Equals(object) uses the typed comparison logic
- add reflection-based tests for Key equality behavior

## Testing
- `dotnet test Tests/MQTTnet.AspNetCore.Routing.Tests/MQTTnet.AspNetCore.Routing.Tests.csproj -c Release --no-build` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_68763f13271c8332add43f7cbba8fa83