### PR TITLE
Fix README license link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ﻿[![NuGet Badge](https://buildstats.info/nuget/MQTTnet.Extensions.ManagedClient.Routing)]([https://www.nuget.org/packages/MQTTnet.AspNetCore.Routing](https://www.nuget.org/packages/MQTTnet.Extensions.ManagedClient.Routing/))
-[![License: MIT](https://img.shields.io/badge/License-MIT-brightgreen.svg)](https://github.com/lucaschoeneberg/MQTTnet.Extensions.ManagedClient.Routing/LICENSE)
+[![License: MIT](https://img.shields.io/badge/License-MIT-brightgreen.svg)](./LICENSE)
 
 # MQTTnet AspNetCore Routing
 
@@ -9,4 +9,4 @@ This addon to MQTTnet provides the ability to define controllers and use attribu
 
 ## MIT License
 
-See https://github.com/IoTSharp/MQTTnet.AspNetCore.Routing/LICENSE.
+This project is released under the [MIT License](./LICENSE).


### PR DESCRIPTION
## Summary
- link license badge to the repo's license file
- clarify that the project uses the MIT License

## Testing
- `dotnet test --no-build --verbosity minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68766c3c0ccc8332869e327d4518c1ec