### PR TITLE
Add contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,24 @@
+# Contributing to MQTTnet.Extensions.ManagedClient.Routing
+
+Thank you for considering contributing to this project!
+
+## Reporting issues
+
+Please use the issue templates located in [.github/ISSUE_TEMPLATE](.github/ISSUE_TEMPLATE) when opening a new issue. Choose the template that best matches your request (bug report, feature request, question or other).
+
+## Submitting pull requests
+
+1. Fork the repository and create your branch from `master`.
+2. Add your changes with clear commit messages.
+3. Ensure the test suite passes by running `dotnet test`.
+4. Open a pull request against this repository and describe your changes.
+
+## Running the tests
+
+The test suite can be executed using the [.NET CLI](https://docs.microsoft.com/dotnet/core/tools/). From the repository root run:
+
+```bash
+dotnet test
+```
+
+

--- a/README.md
+++ b/README.md
@@ -10,3 +10,7 @@ This addon to MQTTnet provides the ability to define controllers and use attribu
 ## MIT License
 
 See https://github.com/IoTSharp/MQTTnet.AspNetCore.Routing/LICENSE.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on how to open issues, submit pull requests and run the test suite.


### PR DESCRIPTION
## Summary
- add CONTRIBUTING docs referencing issue templates and tests
- document how to run tests with `dotnet test`
- link to contributing guide from README

## Testing
- `dotnet test --no-build` *(fails: `command not found`)

------
https://chatgpt.com/codex/tasks/task_e_68766c3f80a48332bc729b786320e113