### PR TITLE
Add escaped token support

### DIFF
--- a/Source/Routing/MqttRouteTableFactory.cs
+++ b/Source/Routing/MqttRouteTableFactory.cs
@@ -140,9 +140,10 @@ namespace MQTTnet.Extensions.ManagedClient.Routing.Routing
         }
 
         /// <summary>
-        /// Given a route template string suchs a "[controller]/[action]" replace the tokens with the values provided.
-        /// /// Controllers with a suffix of "Controller" will be chopped to exclude the word Controller from the
-        /// returns route string.
+        /// Given a route template string such as "[controller]/[action]" replace the tokens with the values provided.
+        /// Controllers with a suffix of "Controller" will be chopped to exclude the word Controller from the
+        /// returned route string. Tokens can be escaped using double brackets "[[controller]]" and "[[action]]" to
+        /// produce the literal text "[controller]" or "[action]" in the resulting route.
         /// </summary>
         /// <param name="template">Template string</param>
         /// <param name="controllerName">Name of the controller object</param>
@@ -150,11 +151,18 @@ namespace MQTTnet.Extensions.ManagedClient.Routing.Routing
         /// <returns>String with replaced values</returns>
         private static string ReplaceTokens(string template, string controllerName, string actionName)
         {
-            // In a future enhancement, we may allow escaping tokens with a "[[" to have feature parity with AspNet routing.
+            // Allow token escaping using double brackets like [[controller]] or [[action]]
+            const string EscapedController = "__escaped_controller__";
+            const string EscapedAction = "__escaped_action__";
+
             return template
+                .Replace("[[controller]]", EscapedController)
+                .Replace("[[action]]", EscapedAction)
                 // Strip "Controller" suffix from controller name if needed
                 .Replace("[controller]", controllerName.EndsWith("Controller") ? controllerName[..^10] : controllerName)
-                .Replace("[action]", actionName);
+                .Replace("[action]", actionName)
+                .Replace(EscapedController, "[controller]")
+                .Replace(EscapedAction, "[action]");
         }
 
         /// <summary>

--- a/Tests/MQTTnet.AspNetCore.Routing.Tests/ReplaceTokensTests.cs
+++ b/Tests/MQTTnet.AspNetCore.Routing.Tests/ReplaceTokensTests.cs
@@ -1,0 +1,31 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Reflection;
+using MQTTnet.Extensions.ManagedClient.Routing.Routing;
+
+namespace MQTTnet.AspNetCore.Routing.Tests
+{
+    [TestClass]
+    public class ReplaceTokensTests
+    {
+        private static MethodInfo GetReplaceTokensMethod()
+        {
+            return typeof(MqttRouteTableFactory).GetMethod("ReplaceTokens", BindingFlags.NonPublic | BindingFlags.Static);
+        }
+
+        [TestMethod]
+        public void ReplaceTokens_EscapedTokensPreserved()
+        {
+            var method = GetReplaceTokensMethod();
+            var result = (string)method.Invoke(null, new object[] { "api/[[controller]]/[[action]]", "FooController", "Bar" });
+            Assert.AreEqual("api/[controller]/[action]", result);
+        }
+
+        [TestMethod]
+        public void ReplaceTokens_MixedTokensReplaced()
+        {
+            var method = GetReplaceTokensMethod();
+            var result = (string)method.Invoke(null, new object[] { "api/[[controller]]/[action]", "SampleController", "Index" });
+            Assert.AreEqual("api/[controller]/Index", result);
+        }
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,7 +17,7 @@ This project adds ASP.NET‑style routing on top of MQTTnet's managed client. Co
 ### Routing attributes
 
 - **`MqttControllerAttribute`** – Marks a class as a controller that can contain routed actions.
-- **`MqttRouteAttribute`** – Specifies the topic template for a controller or action. Tokens such as `[controller]` and `[action]` are replaced with the controller and method names.
+- **`MqttRouteAttribute`** – Specifies the topic template for a controller or action. Tokens such as `[controller]` and `[action]` are replaced with the controller and method names. Use double brackets like `[[controller]]` or `[[action]]` to include the literal token text.
 - **`FromPayloadAttribute`** – Applied to method parameters to deserialize the message payload with the configured JSON options.
 - **`MqttControllerContextAttribute`** – Applied to a property when using custom controllers so that the routing infrastructure can set the `MqttControllerContext` instance.
 


### PR DESCRIPTION
## Summary
- support `[[controller]]` and `[[action]]` tokens
- document escaping in architecture docs
- add tests verifying escaped tokens

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ea73af1048332b36f62198b55dd60