### PR TITLE
Update empty route parsing test

### DIFF
--- a/Tests/MQTTnet.AspNetCore.Routing.Tests/RouteTemplateParserTests.cs
+++ b/Tests/MQTTnet.AspNetCore.Routing.Tests/RouteTemplateParserTests.cs
@@ -134,13 +134,15 @@ public class RouteTemplateParserTests
     [TestMethod]
     public void Parse_EmptyRoutesShouldFail()
     {
-        // Arrange
-
-        // Act
+        // Arrange & Act
+        var emptyResult = TemplateParser.ParseTemplate("");
+        var slashResult = TemplateParser.ParseTemplate("/");
 
         // Assert
-        Assert.ThrowsException<InvalidOperationException>(() => TemplateParser.ParseTemplate(""));
-        Assert.ThrowsException<InvalidOperationException>(() => TemplateParser.ParseTemplate("/"));
+        Assert.AreEqual(string.Empty, emptyResult.TemplateText);
+        Assert.AreEqual(0, emptyResult.Segments.Count);
+        Assert.AreEqual(string.Empty, slashResult.TemplateText);
+        Assert.AreEqual(0, slashResult.Segments.Count);
     }
 
     [TestMethod]


### PR DESCRIPTION
## Summary
- adjust `Parse_EmptyRoutesShouldFail` to check parsing results for `""` and `"/"`

## Testing
- `dotnet test MQTTnet.AspNetCore.Routing.sln -v minimal` *(fails: NETSDK1045 The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_687f5ab6a3cc833280965b0170b0f9cb