### PR TITLE
Add TemplateParser error tests

### DIFF
--- a/Tests/MQTTnet.AspNetCore.Routing.Tests/RouteTemplateParserTests.cs
+++ b/Tests/MQTTnet.AspNetCore.Routing.Tests/RouteTemplateParserTests.cs
@@ -178,4 +178,40 @@ public class RouteTemplateParserTests
         // Assert
         Assert.ThrowsException<InvalidOperationException>(() => TemplateParser.ParseTemplate(template));
     }
+
+    [TestMethod]
+    public void Parse_MissingClosingBraceShouldFail()
+    {
+        // Arrange
+        var template = "{id";
+
+        // Act
+
+        // Assert
+        Assert.ThrowsException<InvalidOperationException>(() => TemplateParser.ParseTemplate(template));
+    }
+
+    [TestMethod]
+    public void Parse_InvalidCharactersInParameterNameShouldFail()
+    {
+        // Arrange
+        var template = "{va.l}";
+
+        // Act
+
+        // Assert
+        Assert.ThrowsException<InvalidOperationException>(() => TemplateParser.ParseTemplate(template));
+    }
+
+    [TestMethod]
+    public void Parse_DuplicateParameterNamesShouldFail()
+    {
+        // Arrange
+        var template = "{id}/{id}";
+
+        // Act
+
+        // Assert
+        Assert.ThrowsException<InvalidOperationException>(() => TemplateParser.ParseTemplate(template));
+    }
 }


### PR DESCRIPTION
## Summary
- add unit tests for missing brace, invalid parameter names, and duplicates

## Testing
- `dotnet test Tests/MQTTnet.AspNetCore.Routing.Tests/MQTTnet.AspNetCore.Routing.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_687f5aaa9b64833288b39d5b8ac56bda