### PR TITLE
Add MqttRouteTableFactory caching tests

### DIFF
--- a/Tests/MQTTnet.AspNetCore.Routing.Tests/MqttRouteTableFactoryCachingTests.cs
+++ b/Tests/MQTTnet.AspNetCore.Routing.Tests/MqttRouteTableFactoryCachingTests.cs
@@ -1,0 +1,28 @@
+using System.Reflection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MQTTnet.Extensions.ManagedClient.Routing.Routing;
+
+namespace MQTTnet.AspNetCore.Routing.Tests;
+
+[TestClass]
+public class MqttRouteTableFactoryCachingTests
+{
+    [TestMethod]
+    public void Create_ReturnsSameInstance_ForSameAssemblies()
+    {
+        var asm = new[] { typeof(MqttRouteTableFactoryCachingTests).Assembly };
+        var table1 = MqttRouteTableFactory.Create(asm);
+        var table2 = MqttRouteTableFactory.Create(new[] { typeof(MqttRouteTableFactoryCachingTests).Assembly });
+
+        Assert.AreSame(table1, table2);
+    }
+
+    [TestMethod]
+    public void Create_ReturnsDifferentInstances_ForDifferentAssemblies()
+    {
+        var table1 = MqttRouteTableFactory.Create(new[] { typeof(MqttRouteTableFactoryCachingTests).Assembly });
+        var table2 = MqttRouteTableFactory.Create(new[] { typeof(System.Net.Http.HttpClient).Assembly });
+
+        Assert.AreNotSame(table1, table2);
+    }
+}


### PR DESCRIPTION
## Summary
- add tests verifying caching behavior of `MqttRouteTableFactory`

## Testing
- `dotnet test Tests/MQTTnet.AspNetCore.Routing.Tests/MQTTnet.AspNetCore.Routing.Tests.csproj -p:TargetFramework=net8.0 -p:TargetFrameworks=net8.0 -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_687f5aaf5324833297b8b1dd00857bc3