### PR TITLE
Fix PackageTags formatting

### DIFF
--- a/Source/MQTTnet.AspNetCore.Routing.csproj
+++ b/Source/MQTTnet.AspNetCore.Routing.csproj
@@ -10,7 +10,7 @@
         </Description>
         <Copyright>Copyright (c) Atlas Lift Tech Inc. 2021</Copyright>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
-        <PackageTags>MQTT Message Queue Telemetry Transport MQTTClient MQTTBroker Broker NETStandard IoT InternetOfThings Messaging Hardware Arduino Sensor Actuator M2M ESP Smart Home Cities Automation Xamarin Blazor AspNetCore</PackageTags>
+        <PackageTags>MQTT;MQTTClient;MQTTBroker;IoT;Messaging;Arduino;Sensor;Actuator;M2M;ESP;SmartHome;Automation;Xamarin;Blazor;AspNetCore</PackageTags>
         <Company>Atlas Lift Tech Inc;IoTSharp</Company>
         <Authors>Anton Vishnyak;maikebing;lucaschoeneberg</Authors>
         <AssemblyVersion>0.4.0</AssemblyVersion>


### PR DESCRIPTION
## Summary
- clean up NuGet PackageTags and use semicolon separators

## Testing
- `dotnet test` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_687f6564a92083329db93cd2fa464701