### PR TITLE
Fix repository links in csproj

### DIFF
--- a/Source/MQTTnet.AspNetCore.Routing.csproj
+++ b/Source/MQTTnet.AspNetCore.Routing.csproj
@@ -16,12 +16,12 @@
         <AssemblyVersion>0.4.0</AssemblyVersion>
         <FileVersion>0.4.0</FileVersion>
         <LangVersion>default</LangVersion>
-        <RepositoryUrl>https://github.com/lucaschoeneberg/MQTTnet.AspNetCore.Routing</RepositoryUrl>
+        <RepositoryUrl>https://github.com/lucaschoeneberg/MQTTnet.Extensions.ManagedClient.Routing</RepositoryUrl>
         <RepositoryType>GIT</RepositoryType>
         <PackageReleaseNotes>Build on top of https://github.com/IoTSharp/MQTTnet.AspNetCore.Routing</PackageReleaseNotes>
         <Version>1.0.2</Version>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-        <PackageProjectUrl>https://github.com/lucaschoeneberg/MQTTnet.AspNetCore.Routing</PackageProjectUrl>
+        <PackageProjectUrl>https://github.com/lucaschoeneberg/MQTTnet.Extensions.ManagedClient.Routing</PackageProjectUrl>
         <PublishRepositoryUrl>true</PublishRepositoryUrl>
         <IncludeSymbols>true</IncludeSymbols>
         <SymbolPackageFormat>snupkg</SymbolPackageFormat>


### PR DESCRIPTION
## Summary
- fix repository links in csproj

## Testing
- `dotnet build --no-restore` *(fails: NETSDK1004 / NETSDK1045)*

------
https://chatgpt.com/codex/tasks/task_e_687f6527516c833283309a68012e77d0